### PR TITLE
Release version 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 * Add a value set that encodes Annex A of the guidelines document, including its derivation.
   See the [README](./annex-A/README.md) for more details.
+* W.r.t. the ["COVID-19 vaccine or prophylaxis" value set](./vaccine-prophylaxis.json), corresponding to the table in § 2.2 in the guidelines document:
+    1. The "J07BX03" ACT code has been deprecated by setting its `active` field's value to `false` and adding a postfix ` (deprecated)` to the `display` field's value.
+    2. The first two entries, for codes "1119349007" and "1119305005", have been swapped to match the order in the document's table.
+    3. Entries for SCT codes "28531000087107" (which replaces the "J07BX03" ACT code), "30141000087107", and "1187593009" have been added.
+* W.r.t. to the ["vaccine encoding instructions" value set](./vaccine-encoding-instructions.json), corresponding to Annex A of the guidelines document:
+    1. All occurrences of the "J07BX03" ACT code in , have been replaced by the "28531000087107" SCT code.
+    2. The derivation script for this value set has been updated to check for deprecated ACT/SCT codes.
+       (It also reports the correct row numbers now.)
 
 
 ## Release 2.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Release 2.11.0
+
+* Add a value set that encodes Annex A of the guidelines document, including its derivation.
+  See the [README](./annex-A/README.md) for more details.
+
 
 ## Release 2.10.0
 
@@ -13,7 +18,7 @@
 
   The [guidelines document v1.13 has been adopted and published](https://ec.europa.eu/health/sites/default/files/ehealth/docs/digital-green-value-sets_en.pdf) through the [eHealth network page on the EU DCC](https://ec.europa.eu/health/ehealth/covid-19_en).
 
-  Version 1.12 of this document has also been adopted after v1.11, but v1.12 only adds a textual clarification which has no impact on the (implementation of the) value sets themselves, and which has been removed again in v1.13.
+  Version 1.12 of this document has also been adopted after v1.11, but v1.12 only adds a textual clarification which has no impact on the (implementation of the) value sets themselves, and an Annex B which has been removed again in v1.13.
 
 
 ## Release 2.9.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the value sets referenced by the EU Digital COVID Certificate (DCC) [JSON Schema](https://github.com/ehn-dcc-development/ehn-dcc-schema).
 
-Release: 2.10.0
+Release: 2.11.0
 
 Note that these value sets do not form a core part of the [JSON Schema](https://github.com/ehn-dcc-development/ehn-dcc-schema) but are referenced by it. These value sets can (and should) be regularly updated and distributed from the main Digital COVID Certificate Gateway (DCCG), under clear versioning and release management.
 

--- a/annex-A/README.md
+++ b/annex-A/README.md
@@ -1,0 +1,32 @@
+# Vaccine encoding instructions
+
+Annex A of the [document on “eHealth Network Guidelines on Value Sets
+for EU Digital COVID Certificates”](https://ec.europa.eu/health/sites/default/files/ehealth/docs/digital-green-value-sets_en.pdf)(eHN, DCC) contains a table that shows the coding combinations of the different vaccine medicinal products with their recommended ATC or SNOMED CT ‘Vaccine’ concept, along with their corresponding marketing authorization holder or manufacturer.
+The table is included to assist implementation efforts.
+
+Until release version 2.10.0 of the eHN EU DCC value sets the table in this Annex A was not encoded in a JSON format in this repository.
+Because of ongoing efforts relating to a WHO/G20 pilot, it has become advantageous to encode the table in Annex A.
+This has resulted in the [`vaccine-encoding-instructions.json` JSON file](../vaccine-encoding-instructions.json).
+
+To reduce tedious manual work (which is inherently somewhat error-prone), encoding the table to produce the corresponding JSON value set file has been (somewhat) automated.
+The steps to perform are:
+
+1. Perform a textual copy of the table from the guidelines document to the [`annex-A/table.tsv` file](./table.tsv).
+  This seems to work best from a `.docx` version of that document, rather than the published PDF file.
+2. Clean up the [`annex-A/table.tsv` file](./table.tsv) so that every line in it corresponds to exactly one row in the table.
+  It might be necessary to remove some newlines or other characters for that.
+3. Run the [`build.sh` build script](./build.sh).
+  This should produce the [`vaccine-encoding-instructions.json` JSON file](../vaccine-encoding-instructions.json).
+  If derivation of that file fails, then the file is *not* updated.
+  In principle, you'd expect the top-level `valueSetDate` field to be updated (to the date of today).
+  You could also inspect that file's metadata to be sure.
+4. Inspect the console.
+  The derivation prints issues (error, warnings, infos) there (if there are any).
+  If there are any manufacturers that are associated with multiple vaccines, a piece of JSON detailing those associations is printed to the console.
+5. Compare the updated file against the last version committed to the Git versioning system.
+  If there are more differences between these versions than expected, you need to have to look at the [`annex-A/table.tsv` file](./table.tsv) to see whether (and if so, how) that needs to be tweaked.
+  Issues printed to the console by running the script might help as well.
+
+The derivation relies on the Deno runtime for JavaScript/TypeScript.
+It can be found and downloaded at https://deno.land/.
+

--- a/annex-A/as-json.ts
+++ b/annex-A/as-json.ts
@@ -50,13 +50,13 @@ const prophylaxis = readAsJson("../vaccine-prophylaxis.json")
 const deprecationPostfix = " (deprecated)"
 keyedEncodings.forEach(([key, mapping], i) => {
 
-    const rowInfix = `@ encoding row ${i+1} for "${key}"`
+    const rowInfix = `@ mapping row ${i+2} for "${key}"`
     const warnHeader = `[WARN] ${rowInfix}:`
 
     const vaccineCode = mapping["vaccine-code"]
     const withoutDeprecation = vaccineCode.endsWith(deprecationPostfix) ? vaccineCode.substring(0, vaccineCode.length - deprecationPostfix.length) : vaccineCode
     if (vaccineCode.endsWith(deprecationPostfix)) {
-        console.info(`[INFO] ${rowInfix}: vaccine code "${withoutDeprecation}" occurs with deprecation postfix`)
+        console.info(`[INFO] ${rowInfix}: vaccine with code "${withoutDeprecation}" occurs even though the vaccine's been deprecated`)
     }
 
     if (!(withoutDeprecation in medicinalProduct.valueSetValues)) {
@@ -74,7 +74,12 @@ keyedEncodings.forEach(([key, mapping], i) => {
         console.warn(`${warnHeader} mappings to duplicate prophylaxes occur`)
     }
     mapping["sct-codes"].forEach((sctCode) => {
-        if (!(sctCode in prophylaxis.valueSetValues)) {
+        if (sctCode in prophylaxis.valueSetValues) {
+            const sct = prophylaxis.valueSetValues[sctCode]
+            if (!sct["active"]) {
+                console.warn(`${warnHeader} prophylaxis code "${sctCode}" is used despite it being deprecated`)
+            }
+        } else {
             console.warn(`${warnHeader} prophylaxis code "${sctCode}" doesn't exist in value set "sct-vaccines-covid-19"`)
         }
     })
@@ -88,7 +93,8 @@ const manufacturersWithMultipleVaccines =
         .map(([key, encodings]) => [key, encodings.map(([_, mapping]) => mapping["vaccine-code"])])
 
 if (manufacturersWithMultipleVaccines.length > 0) {
-    console.log(`manufacturers with more than 1 vaccine:`)
+    console.log()
+    console.log(`[INFO] manufacturers with more than 1 vaccine:`)
     console.dir(manufacturersWithMultipleVaccines)
 }
 

--- a/annex-A/as-json.ts
+++ b/annex-A/as-json.ts
@@ -1,0 +1,116 @@
+import {fileAsLines, readAsJson} from "./files.ts"
+import {groupBy} from "./functional.ts"
+
+
+const tableLines = fileAsLines("table.tsv")
+/*
+ * The contents of the 'table.tsv' file are copied from the table in Annex A of the guidelines document,
+ * after which some spurious newlines are cleaned up.
+ */
+
+
+const cleanUp = (str: string) => {
+    const match = str.match(/^"\s*(.+?)\s*"$/)
+    return match
+        ? match[1]
+        : str
+}
+
+
+type Mapping = {
+    "vaccine-code": string
+    "vaccine-manufacturer": string
+    "sct-codes": string[]
+    "note": string
+}
+
+const lineAsEncoding = (line: string): [string, Mapping] => {
+    const parts = line.split(/\t/).map(cleanUp)
+    return [
+        parts[0],
+        {
+            "vaccine-code": parts[1],
+            "vaccine-manufacturer": parts[2],
+            "sct-codes": /* parts[3] === undefined ? [] : */parts[3].split(/\s+or\s+/),
+            "note": parts[4]
+        }
+    ]
+}
+
+const keyedEncodings: [string, Mapping][] = tableLines
+    .slice(1)
+    .map(lineAsEncoding)
+
+
+// check against other value sets:
+const medicinalProduct = readAsJson("../vaccine-medicinal-product.json")
+const manufacturers = readAsJson("../vaccine-mah-manf.json")
+const prophylaxis = readAsJson("../vaccine-prophylaxis.json")
+
+const deprecationPostfix = " (deprecated)"
+keyedEncodings.forEach(([key, mapping], i) => {
+
+    const rowInfix = `@ encoding row ${i+1} for "${key}"`
+    const warnHeader = `[WARN] ${rowInfix}:`
+
+    const vaccineCode = mapping["vaccine-code"]
+    const withoutDeprecation = vaccineCode.endsWith(deprecationPostfix) ? vaccineCode.substring(0, vaccineCode.length - deprecationPostfix.length) : vaccineCode
+    if (vaccineCode.endsWith(deprecationPostfix)) {
+        console.info(`[INFO] ${rowInfix}: vaccine code "${withoutDeprecation}" occurs with deprecation postfix`)
+    }
+
+    if (!(withoutDeprecation in medicinalProduct.valueSetValues)) {
+        console.warn(`${warnHeader} vaccine code "${mapping["vaccine-code"]}" doesn't exist in value set "vaccines-covid-19-names"`)
+    }
+
+    if (!(mapping["vaccine-manufacturer"] in manufacturers.valueSetValues)) {
+        console.warn(`${warnHeader} vaccine manufacturer with ID "${mapping["vaccine-manufacturer"]}" doesn't exist in value set "vaccines-covid-19-auth-holders"`)
+    }
+
+    if (mapping["sct-codes"].length === 0) {
+        console.warn(`${warnHeader} no mapping to prophylaxes`)
+    }
+    if (new Set(...mapping["sct-codes"]).size < mapping["sct-codes"].length) {
+        console.warn(`${warnHeader} mappings to duplicate prophylaxes occur`)
+    }
+    mapping["sct-codes"].forEach((sctCode) => {
+        if (!(sctCode in prophylaxis.valueSetValues)) {
+            console.warn(`${warnHeader} prophylaxis code "${sctCode}" doesn't exist in value set "sct-vaccines-covid-19"`)
+        }
+    })
+
+})
+
+
+const manufacturersWithMultipleVaccines =
+    groupBy(keyedEncodings, ([_, mapping]) => mapping["vaccine-manufacturer"])
+        .filter(([_, encodings]) => encodings.length > 1)
+        .map(([key, encodings]) => [key, encodings.map(([_, mapping]) => mapping["vaccine-code"])])
+
+if (manufacturersWithMultipleVaccines.length > 0) {
+    console.log(`manufacturers with more than 1 vaccine:`)
+    console.dir(manufacturersWithMultipleVaccines)
+}
+
+
+// check for duplicate keys:
+const encodingsPerKey = groupBy(keyedEncodings, ([key]) => key)
+const duplicateKeyEntries = encodingsPerKey.filter(([_, group]) => group.length > 1)
+if (duplicateKeyEntries.length > 0) {
+    console.error(`[ERROR] key occurs more than once: ${duplicateKeyEntries.map(([key]) => `"${key}"`).join(", ")}`)
+    console.error(`    - (exiting before saving)`)
+    Deno.exit(1)
+}
+
+
+const valueSet = {
+    "valueSetId": "vaccines-covid-19-encoding-instructions",
+    "valueSetDate": new Date().toISOString().slice(0, 10),
+    "valueSetValues": Object.fromEntries(keyedEncodings)
+}
+
+Deno.writeTextFileSync(
+    "../vaccine-encoding-instructions.json",
+    JSON.stringify(valueSet, null, 2)
+)
+

--- a/annex-A/build.sh
+++ b/annex-A/build.sh
@@ -1,0 +1,1 @@
+deno run --allow-read --allow-write as-json.ts

--- a/annex-A/files.ts
+++ b/annex-A/files.ts
@@ -1,0 +1,16 @@
+export const fileAsString = (path: string): string =>
+    new TextDecoder().decode(Deno.readFileSync(path))
+
+
+export const fileAsLines = (path: string): string[] => {
+    const lines = fileAsString(path)
+        .split(/\n/)    // split on newlines
+    return lines[lines.length - 1] === ""
+        ? lines.slice(0, lines.length - 1)
+        : lines
+}
+
+
+export const readAsJson = (path: string): any =>
+    JSON.parse(fileAsString(path))
+

--- a/annex-A/functional.ts
+++ b/annex-A/functional.ts
@@ -1,0 +1,13 @@
+export const groupBy = <T>(ts: T[], keyFunc: (t: T) => string): [key: string, values: T[]][] => {
+    const map: { [key: string]: T[] } = {}
+    ts.forEach((t) => {
+        const key = keyFunc(t)
+        let group = map[key]
+        if (group === undefined) {
+            group = map[key] = []
+        }
+        group.push(t)
+    })
+    return Object.entries(map)
+}
+

--- a/annex-A/table.tsv
+++ b/annex-A/table.tsv
@@ -1,39 +1,39 @@
 Vaccine name	Vaccine code	Vaccine Manufacturer or MAH code	Vaccine type	Note
-Comirnaty	EU/1/20/1528	ORG-100030215	1119349007 or J07BX03	The same code should be used also for adapted Comirnaty vaccines (such as bivalent Original/Omicron BA.1 and Original/Omicron BA.4-5) unless indicated otherwise.
-Spikevax	EU/1/20/1507	ORG-100031184	1119349007 or J07BX03	"Previously COVID-19 Vaccine Moderna. The same code should be used also for adapted Spikevax vaccines (such as bivalent Original/Omicron BA.1) unless indicated otherwise."
-"Vaxzevria"	EU/1/21/1529	"ORG-100001699"	J07BX03 or 29061000087103	Use also for AstraZeneca covid-19 vaccines, except R-COVI, Covishield and Covid-19 (recombinant) by Fiocruz.
-Jcovden	EU/1/20/1525	ORG-100001417	J07BX03 or 29061000087103	Previously known as COVID-19 Vaccine Janssen.
-CVnCoV	CVnCoV	ORG-100006270	1119349007 or J07BX03
-NVX-CoV2373	"NVX-CoV2373 (deprecated)"	ORG-100032020	J07BX03 or 1162643001	Do not use this code for new certificates, see entry for Nuvaxovid.
-Sputnik V	Sputnik-V	Gamaleya-Research-Institute	J07BX03 or 29061000087103
-Convidecia	Convidecia	ORG-100013793	J07BX03 or 29061000087103
-EpiVacCorona	EpiVacCorona	Vector-Institute	J07BX03 or 1162643001
-BBIBP-CorV	BBIBP-CorV	ORG-100020693	J07BX03 or 1157024006
-Inactivated SARS-CoV-2 (Vero Cell)	Inactivated-SARS-CoV-2-Vero-Cell	ORG-100010771	J07BX03 or 1157024006	Do not use this code for new certificates, see entry for WIBP-CorV.
-CoronaVac	CoronaVac	Sinovac-Biotech	J07BX03 or 1157024006	Do not use for Vacina adsorvida covid-19 (inativada) by Institito Butantan.
-Covaxin	Covaxin	Bharat-Biotech	J07BX03 or 1157024006	Also known as BBV152 A, B, C.
-Covishield	Covishield	ORG-100001981	J07BX03 or 29061000087103	Also known as ChAdOx1_nCoV-19.
-Covid-19 (recombinant)	Covid-19-recombinant	Fiocruz	J07BX03 or 29061000087103
-R-COVI	R-COVI	ORG-100007893	J07BX03 or 29061000087103
-CoviVac	CoviVac	Chumakov-Federal-Scientific-Center	J07BX03 or 1157024006
-Sputnik Light	Sputnik-Light	Gamaleya-Research-Institute	J07BX03 or 29061000087103
-Hayat-Vax	Hayat-Vax	ORG-100023050	J07BX03 or 1157024006
-Abdala	Abdala	CIGB	J07BX03	Also known as CIGB-66.
-WIBP-CorV	WIBP-CorV	Sinopharm-WIBP	J07BX03 or 1157024006	Previously known as Inactivated SARS-CoV-2 (Vero Cell).
-MVC COVID-19 vaccine	MVC-COV1901	ORG-100033914	J07BX03 or 1162643001	Also known as Medigen COVID-19 vaccine.
-Nuvaxovid	EU/1/21/1618	ORG-100032020	J07BX03 or 1162643001	Previously known as NVX-CoV2373.
-Covovax	Covovax	ORG-100001981	J07BX03 or 1162643001	Do not confuse with Nuvaxovid.
-Vidprevtyn	"Vidprevtyn (deprecated)"	ORG-100000788	J07BX03	Do not use this code for new certificates, see entry for VidPrevtyn Beta.
-VLA2001	"VLA2001 (deprecated)"	ORG-100036422	J07BX03	Do not use this code for new certificates, see entry for COVID-19 Vaccine (inactivated, adjuvanted) Valneva.
-Sputnik M	Sputnik-M	Gamaleya-Research-Institute	J07BX03 or 29061000087103	Do not confuse with Sputnik V or Sputnik Light.
-EpiVacCorona-N	EpiVacCorona-N	Vector-Institute	J07BX03 or 1162643001	Do not confuse with EpiVacCorona. Also know as Aurora-CoV.
-Vacina adsorvida covid-19 (inativada)	Covid-19-adsorvida-inativada	Instituto-Butantan	J07BX03 or 1157024006
-NVSI-06-08	NVSI-06-08	NVSI	J07BX03	Also known as Recombinant SARS-CoV-2 vaccine (CHO Cell).
-YS-SC2-010	YS-SC2-010	Yisheng-Biopharma	J07BX03	Also known as PIKA-Adjuvanted Recombinant SARS-CoV-2 Spike (S) Protein Subunit vaccine.
-SCTV01C	SCTV01C	ORG-100026614	J07BX03	Also known as Bivalent Recombinant Trimeric S Protein vaccine.
-Covifenz	Covifenz	ORG-100008549	J07BX03	Also known as CoVLP and Medicago plant-based VLP.
-AZD2816	AZD2816	"ORG-100001699"	J07BX03 or 29061000087103
-Soberana 02	Soberana-02	Finlay-Institute	J07BX03	Also known as FINLAY-FR-2.
-Soberana Plus	Soberana-Plus	Finlay-Institute	J07BX03	Also known as FINLAY-FR-1A.
-COVID-19 Vaccine Valneva	"EU/1/21/1624"	ORG-100036422	J07BX03	Previously known as VLA2001.
-VidPrevtyn Beta	EU/1/21/1580	ORG-100000788	J07BX03	Previously known as Vidprevtyn.
+Comirnaty	EU/1/20/1528	ORG-100030215	1119349007 or 28531000087107	The same code should be used also for adapted Comirnaty vaccines (such as bivalent Original/Omicron BA.1 and Original/Omicron BA.4-5) unless indicated otherwise.
+Spikevax	EU/1/20/1507	ORG-100031184	1119349007 or 28531000087107	"Previously COVID-19 Vaccine Moderna. The same code should be used also for adapted Spikevax vaccines (such as bivalent Original/Omicron BA.1) unless indicated otherwise."
+"Vaxzevria"	EU/1/21/1529	"ORG-100001699"	28531000087107 or 29061000087103	Use also for AstraZeneca covid-19 vaccines, except R-COVI, Covishield and Covid-19 (recombinant) by Fiocruz.
+Jcovden	EU/1/20/1525	ORG-100001417	28531000087107 or 29061000087103	Previously known as COVID-19 Vaccine Janssen.
+CVnCoV	CVnCoV	ORG-100006270	1119349007 or 28531000087107
+NVX-CoV2373	"NVX-CoV2373 (deprecated)"	ORG-100032020	28531000087107 or 1162643001	Do not use this code for new certificates, see entry for Nuvaxovid.
+Sputnik V	Sputnik-V	Gamaleya-Research-Institute	28531000087107 or 29061000087103
+Convidecia	Convidecia	ORG-100013793	28531000087107 or 29061000087103
+EpiVacCorona	EpiVacCorona	Vector-Institute	28531000087107 or 1162643001
+BBIBP-CorV	BBIBP-CorV	ORG-100020693	28531000087107 or 1157024006
+Inactivated SARS-CoV-2 (Vero Cell)	Inactivated-SARS-CoV-2-Vero-Cell	ORG-100010771	28531000087107 or 1157024006	Do not use this code for new certificates, see entry for WIBP-CorV.
+CoronaVac	CoronaVac	Sinovac-Biotech	28531000087107 or 1157024006	Do not use for Vacina adsorvida covid-19 (inativada) by Institito Butantan.
+Covaxin	Covaxin	Bharat-Biotech	28531000087107 or 1157024006	Also known as BBV152 A, B, C.
+Covishield	Covishield	ORG-100001981	28531000087107 or 29061000087103	Also known as ChAdOx1_nCoV-19.
+Covid-19 (recombinant)	Covid-19-recombinant	Fiocruz	28531000087107 or 29061000087103
+R-COVI	R-COVI	ORG-100007893	28531000087107 or 29061000087103
+CoviVac	CoviVac	Chumakov-Federal-Scientific-Center	28531000087107 or 1157024006
+Sputnik Light	Sputnik-Light	Gamaleya-Research-Institute	28531000087107 or 29061000087103
+Hayat-Vax	Hayat-Vax	ORG-100023050	28531000087107 or 1157024006
+Abdala	Abdala	CIGB	28531000087107	Also known as CIGB-66.
+WIBP-CorV	WIBP-CorV	Sinopharm-WIBP	28531000087107 or 1157024006	Previously known as Inactivated SARS-CoV-2 (Vero Cell).
+MVC COVID-19 vaccine	MVC-COV1901	ORG-100033914	28531000087107 or 1162643001	Also known as Medigen COVID-19 vaccine.
+Nuvaxovid	EU/1/21/1618	ORG-100032020	28531000087107 or 1162643001	Previously known as NVX-CoV2373.
+Covovax	Covovax	ORG-100001981	28531000087107 or 1162643001	Do not confuse with Nuvaxovid.
+Vidprevtyn	"Vidprevtyn (deprecated)"	ORG-100000788	28531000087107	Do not use this code for new certificates, see entry for VidPrevtyn Beta.
+VLA2001	"VLA2001 (deprecated)"	ORG-100036422	28531000087107	Do not use this code for new certificates, see entry for COVID-19 Vaccine (inactivated, adjuvanted) Valneva.
+Sputnik M	Sputnik-M	Gamaleya-Research-Institute	28531000087107 or 29061000087103	Do not confuse with Sputnik V or Sputnik Light.
+EpiVacCorona-N	EpiVacCorona-N	Vector-Institute	28531000087107 or 1162643001	Do not confuse with EpiVacCorona. Also know as Aurora-CoV.
+Vacina adsorvida covid-19 (inativada)	Covid-19-adsorvida-inativada	Instituto-Butantan	28531000087107 or 1157024006
+NVSI-06-08	NVSI-06-08	NVSI	28531000087107	Also known as Recombinant SARS-CoV-2 vaccine (CHO Cell).
+YS-SC2-010	YS-SC2-010	Yisheng-Biopharma	28531000087107	Also known as PIKA-Adjuvanted Recombinant SARS-CoV-2 Spike (S) Protein Subunit vaccine.
+SCTV01C	SCTV01C	ORG-100026614	28531000087107	Also known as Bivalent Recombinant Trimeric S Protein vaccine.
+Covifenz	Covifenz	ORG-100008549	28531000087107	Also known as CoVLP and Medicago plant-based VLP.
+AZD2816	AZD2816	"ORG-100001699"	28531000087107 or 29061000087103
+Soberana 02	Soberana-02	Finlay-Institute	28531000087107	Also known as FINLAY-FR-2.
+Soberana Plus	Soberana-Plus	Finlay-Institute	28531000087107	Also known as FINLAY-FR-1A.
+COVID-19 Vaccine Valneva	"EU/1/21/1624"	ORG-100036422	28531000087107	Previously known as VLA2001.
+VidPrevtyn Beta	EU/1/21/1580	ORG-100000788	28531000087107	Previously known as Vidprevtyn.

--- a/annex-A/table.tsv
+++ b/annex-A/table.tsv
@@ -1,0 +1,39 @@
+Vaccine name	Vaccine code	Vaccine Manufacturer or MAH code	Vaccine type	Note
+Comirnaty	EU/1/20/1528	ORG-100030215	1119349007 or J07BX03	The same code should be used also for adapted Comirnaty vaccines (such as bivalent Original/Omicron BA.1 and Original/Omicron BA.4-5) unless indicated otherwise.
+Spikevax	EU/1/20/1507	ORG-100031184	1119349007 or J07BX03	"Previously COVID-19 Vaccine Moderna. The same code should be used also for adapted Spikevax vaccines (such as bivalent Original/Omicron BA.1) unless indicated otherwise."
+"Vaxzevria"	EU/1/21/1529	"ORG-100001699"	J07BX03 or 29061000087103	Use also for AstraZeneca covid-19 vaccines, except R-COVI, Covishield and Covid-19 (recombinant) by Fiocruz.
+Jcovden	EU/1/20/1525	ORG-100001417	J07BX03 or 29061000087103	Previously known as COVID-19 Vaccine Janssen.
+CVnCoV	CVnCoV	ORG-100006270	1119349007 or J07BX03
+NVX-CoV2373	"NVX-CoV2373 (deprecated)"	ORG-100032020	J07BX03 or 1162643001	Do not use this code for new certificates, see entry for Nuvaxovid.
+Sputnik V	Sputnik-V	Gamaleya-Research-Institute	J07BX03 or 29061000087103
+Convidecia	Convidecia	ORG-100013793	J07BX03 or 29061000087103
+EpiVacCorona	EpiVacCorona	Vector-Institute	J07BX03 or 1162643001
+BBIBP-CorV	BBIBP-CorV	ORG-100020693	J07BX03 or 1157024006
+Inactivated SARS-CoV-2 (Vero Cell)	Inactivated-SARS-CoV-2-Vero-Cell	ORG-100010771	J07BX03 or 1157024006	Do not use this code for new certificates, see entry for WIBP-CorV.
+CoronaVac	CoronaVac	Sinovac-Biotech	J07BX03 or 1157024006	Do not use for Vacina adsorvida covid-19 (inativada) by Institito Butantan.
+Covaxin	Covaxin	Bharat-Biotech	J07BX03 or 1157024006	Also known as BBV152 A, B, C.
+Covishield	Covishield	ORG-100001981	J07BX03 or 29061000087103	Also known as ChAdOx1_nCoV-19.
+Covid-19 (recombinant)	Covid-19-recombinant	Fiocruz	J07BX03 or 29061000087103
+R-COVI	R-COVI	ORG-100007893	J07BX03 or 29061000087103
+CoviVac	CoviVac	Chumakov-Federal-Scientific-Center	J07BX03 or 1157024006
+Sputnik Light	Sputnik-Light	Gamaleya-Research-Institute	J07BX03 or 29061000087103
+Hayat-Vax	Hayat-Vax	ORG-100023050	J07BX03 or 1157024006
+Abdala	Abdala	CIGB	J07BX03	Also known as CIGB-66.
+WIBP-CorV	WIBP-CorV	Sinopharm-WIBP	J07BX03 or 1157024006	Previously known as Inactivated SARS-CoV-2 (Vero Cell).
+MVC COVID-19 vaccine	MVC-COV1901	ORG-100033914	J07BX03 or 1162643001	Also known as Medigen COVID-19 vaccine.
+Nuvaxovid	EU/1/21/1618	ORG-100032020	J07BX03 or 1162643001	Previously known as NVX-CoV2373.
+Covovax	Covovax	ORG-100001981	J07BX03 or 1162643001	Do not confuse with Nuvaxovid.
+Vidprevtyn	"Vidprevtyn (deprecated)"	ORG-100000788	J07BX03	Do not use this code for new certificates, see entry for VidPrevtyn Beta.
+VLA2001	"VLA2001 (deprecated)"	ORG-100036422	J07BX03	Do not use this code for new certificates, see entry for COVID-19 Vaccine (inactivated, adjuvanted) Valneva.
+Sputnik M	Sputnik-M	Gamaleya-Research-Institute	J07BX03 or 29061000087103	Do not confuse with Sputnik V or Sputnik Light.
+EpiVacCorona-N	EpiVacCorona-N	Vector-Institute	J07BX03 or 1162643001	Do not confuse with EpiVacCorona. Also know as Aurora-CoV.
+Vacina adsorvida covid-19 (inativada)	Covid-19-adsorvida-inativada	Instituto-Butantan	J07BX03 or 1157024006
+NVSI-06-08	NVSI-06-08	NVSI	J07BX03	Also known as Recombinant SARS-CoV-2 vaccine (CHO Cell).
+YS-SC2-010	YS-SC2-010	Yisheng-Biopharma	J07BX03	Also known as PIKA-Adjuvanted Recombinant SARS-CoV-2 Spike (S) Protein Subunit vaccine.
+SCTV01C	SCTV01C	ORG-100026614	J07BX03	Also known as Bivalent Recombinant Trimeric S Protein vaccine.
+Covifenz	Covifenz	ORG-100008549	J07BX03	Also known as CoVLP and Medicago plant-based VLP.
+AZD2816	AZD2816	"ORG-100001699"	J07BX03 or 29061000087103
+Soberana 02	Soberana-02	Finlay-Institute	J07BX03	Also known as FINLAY-FR-2.
+Soberana Plus	Soberana-Plus	Finlay-Institute	J07BX03	Also known as FINLAY-FR-1A.
+COVID-19 Vaccine Valneva	"EU/1/21/1624"	ORG-100036422	J07BX03	Previously known as VLA2001.
+VidPrevtyn Beta	EU/1/21/1580	ORG-100000788	J07BX03	Previously known as Vidprevtyn.

--- a/source-update/README.md
+++ b/source-update/README.md
@@ -1,4 +1,4 @@
-# EU eHealthNetwork Digitial COVID Certificate RAT list update script
+# EU eHealthNetwork Digital COVID Certificate RAT list update script
 
 
 

--- a/vaccine-encoding-instructions.json
+++ b/vaccine-encoding-instructions.json
@@ -1,13 +1,13 @@
 {
   "valueSetId": "vaccines-covid-19-encoding-instructions",
-  "valueSetDate": "2022-12-13",
+  "valueSetDate": "2023-01-26",
   "valueSetValues": {
     "Comirnaty": {
       "vaccine-code": "EU/1/20/1528",
       "vaccine-manufacturer": "ORG-100030215",
       "sct-codes": [
         "1119349007",
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "The same code should be used also for adapted Comirnaty vaccines (such as bivalent Original/Omicron BA.1 and Original/Omicron BA.4-5) unless indicated otherwise."
     },
@@ -16,7 +16,7 @@
       "vaccine-manufacturer": "ORG-100031184",
       "sct-codes": [
         "1119349007",
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Previously COVID-19 Vaccine Moderna. The same code should be used also for adapted Spikevax vaccines (such as bivalent Original/Omicron BA.1) unless indicated otherwise."
     },
@@ -24,7 +24,7 @@
       "vaccine-code": "EU/1/21/1529",
       "vaccine-manufacturer": "ORG-100001699",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ],
       "note": "Use also for AstraZeneca covid-19 vaccines, except R-COVI, Covishield and Covid-19 (recombinant) by Fiocruz."
@@ -33,7 +33,7 @@
       "vaccine-code": "EU/1/20/1525",
       "vaccine-manufacturer": "ORG-100001417",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ],
       "note": "Previously known as COVID-19 Vaccine Janssen."
@@ -43,14 +43,14 @@
       "vaccine-manufacturer": "ORG-100006270",
       "sct-codes": [
         "1119349007",
-        "J07BX03"
+        "28531000087107"
       ]
     },
     "NVX-CoV2373": {
       "vaccine-code": "NVX-CoV2373 (deprecated)",
       "vaccine-manufacturer": "ORG-100032020",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1162643001"
       ],
       "note": "Do not use this code for new certificates, see entry for Nuvaxovid."
@@ -59,7 +59,7 @@
       "vaccine-code": "Sputnik-V",
       "vaccine-manufacturer": "Gamaleya-Research-Institute",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ]
     },
@@ -67,7 +67,7 @@
       "vaccine-code": "Convidecia",
       "vaccine-manufacturer": "ORG-100013793",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ]
     },
@@ -75,7 +75,7 @@
       "vaccine-code": "EpiVacCorona",
       "vaccine-manufacturer": "Vector-Institute",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1162643001"
       ]
     },
@@ -83,7 +83,7 @@
       "vaccine-code": "BBIBP-CorV",
       "vaccine-manufacturer": "ORG-100020693",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ]
     },
@@ -91,7 +91,7 @@
       "vaccine-code": "Inactivated-SARS-CoV-2-Vero-Cell",
       "vaccine-manufacturer": "ORG-100010771",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ],
       "note": "Do not use this code for new certificates, see entry for WIBP-CorV."
@@ -100,7 +100,7 @@
       "vaccine-code": "CoronaVac",
       "vaccine-manufacturer": "Sinovac-Biotech",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ],
       "note": "Do not use for Vacina adsorvida covid-19 (inativada) by Institito Butantan."
@@ -109,7 +109,7 @@
       "vaccine-code": "Covaxin",
       "vaccine-manufacturer": "Bharat-Biotech",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ],
       "note": "Also known as BBV152 A, B, C."
@@ -118,7 +118,7 @@
       "vaccine-code": "Covishield",
       "vaccine-manufacturer": "ORG-100001981",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ],
       "note": "Also known as ChAdOx1_nCoV-19."
@@ -127,7 +127,7 @@
       "vaccine-code": "Covid-19-recombinant",
       "vaccine-manufacturer": "Fiocruz",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ]
     },
@@ -135,7 +135,7 @@
       "vaccine-code": "R-COVI",
       "vaccine-manufacturer": "ORG-100007893",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ]
     },
@@ -143,7 +143,7 @@
       "vaccine-code": "CoviVac",
       "vaccine-manufacturer": "Chumakov-Federal-Scientific-Center",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ]
     },
@@ -151,7 +151,7 @@
       "vaccine-code": "Sputnik-Light",
       "vaccine-manufacturer": "Gamaleya-Research-Institute",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ]
     },
@@ -159,7 +159,7 @@
       "vaccine-code": "Hayat-Vax",
       "vaccine-manufacturer": "ORG-100023050",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ]
     },
@@ -167,7 +167,7 @@
       "vaccine-code": "Abdala",
       "vaccine-manufacturer": "CIGB",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as CIGB-66."
     },
@@ -175,7 +175,7 @@
       "vaccine-code": "WIBP-CorV",
       "vaccine-manufacturer": "Sinopharm-WIBP",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ],
       "note": "Previously known as Inactivated SARS-CoV-2 (Vero Cell)."
@@ -184,7 +184,7 @@
       "vaccine-code": "MVC-COV1901",
       "vaccine-manufacturer": "ORG-100033914",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1162643001"
       ],
       "note": "Also known as Medigen COVID-19 vaccine."
@@ -193,7 +193,7 @@
       "vaccine-code": "EU/1/21/1618",
       "vaccine-manufacturer": "ORG-100032020",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1162643001"
       ],
       "note": "Previously known as NVX-CoV2373."
@@ -202,7 +202,7 @@
       "vaccine-code": "Covovax",
       "vaccine-manufacturer": "ORG-100001981",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1162643001"
       ],
       "note": "Do not confuse with Nuvaxovid."
@@ -211,7 +211,7 @@
       "vaccine-code": "Vidprevtyn (deprecated)",
       "vaccine-manufacturer": "ORG-100000788",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Do not use this code for new certificates, see entry for VidPrevtyn Beta."
     },
@@ -219,7 +219,7 @@
       "vaccine-code": "VLA2001 (deprecated)",
       "vaccine-manufacturer": "ORG-100036422",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Do not use this code for new certificates, see entry for COVID-19 Vaccine (inactivated, adjuvanted) Valneva."
     },
@@ -227,7 +227,7 @@
       "vaccine-code": "Sputnik-M",
       "vaccine-manufacturer": "Gamaleya-Research-Institute",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ],
       "note": "Do not confuse with Sputnik V or Sputnik Light."
@@ -236,7 +236,7 @@
       "vaccine-code": "EpiVacCorona-N",
       "vaccine-manufacturer": "Vector-Institute",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1162643001"
       ],
       "note": "Do not confuse with EpiVacCorona. Also know as Aurora-CoV."
@@ -245,7 +245,7 @@
       "vaccine-code": "Covid-19-adsorvida-inativada",
       "vaccine-manufacturer": "Instituto-Butantan",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "1157024006"
       ]
     },
@@ -253,7 +253,7 @@
       "vaccine-code": "NVSI-06-08",
       "vaccine-manufacturer": "NVSI",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as Recombinant SARS-CoV-2 vaccine (CHO Cell)."
     },
@@ -261,7 +261,7 @@
       "vaccine-code": "YS-SC2-010",
       "vaccine-manufacturer": "Yisheng-Biopharma",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as PIKA-Adjuvanted Recombinant SARS-CoV-2 Spike (S) Protein Subunit vaccine."
     },
@@ -269,7 +269,7 @@
       "vaccine-code": "SCTV01C",
       "vaccine-manufacturer": "ORG-100026614",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as Bivalent Recombinant Trimeric S Protein vaccine."
     },
@@ -277,7 +277,7 @@
       "vaccine-code": "Covifenz",
       "vaccine-manufacturer": "ORG-100008549",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as CoVLP and Medicago plant-based VLP."
     },
@@ -285,7 +285,7 @@
       "vaccine-code": "AZD2816",
       "vaccine-manufacturer": "ORG-100001699",
       "sct-codes": [
-        "J07BX03",
+        "28531000087107",
         "29061000087103"
       ]
     },
@@ -293,7 +293,7 @@
       "vaccine-code": "Soberana-02",
       "vaccine-manufacturer": "Finlay-Institute",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as FINLAY-FR-2."
     },
@@ -301,7 +301,7 @@
       "vaccine-code": "Soberana-Plus",
       "vaccine-manufacturer": "Finlay-Institute",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Also known as FINLAY-FR-1A."
     },
@@ -309,7 +309,7 @@
       "vaccine-code": "EU/1/21/1624",
       "vaccine-manufacturer": "ORG-100036422",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Previously known as VLA2001."
     },
@@ -317,7 +317,7 @@
       "vaccine-code": "EU/1/21/1580",
       "vaccine-manufacturer": "ORG-100000788",
       "sct-codes": [
-        "J07BX03"
+        "28531000087107"
       ],
       "note": "Previously known as Vidprevtyn."
     }

--- a/vaccine-encoding-instructions.json
+++ b/vaccine-encoding-instructions.json
@@ -1,0 +1,325 @@
+{
+  "valueSetId": "vaccines-covid-19-encoding-instructions",
+  "valueSetDate": "2022-12-13",
+  "valueSetValues": {
+    "Comirnaty": {
+      "vaccine-code": "EU/1/20/1528",
+      "vaccine-manufacturer": "ORG-100030215",
+      "sct-codes": [
+        "1119349007",
+        "J07BX03"
+      ],
+      "note": "The same code should be used also for adapted Comirnaty vaccines (such as bivalent Original/Omicron BA.1 and Original/Omicron BA.4-5) unless indicated otherwise."
+    },
+    "Spikevax": {
+      "vaccine-code": "EU/1/20/1507",
+      "vaccine-manufacturer": "ORG-100031184",
+      "sct-codes": [
+        "1119349007",
+        "J07BX03"
+      ],
+      "note": "Previously COVID-19 Vaccine Moderna. The same code should be used also for adapted Spikevax vaccines (such as bivalent Original/Omicron BA.1) unless indicated otherwise."
+    },
+    "Vaxzevria": {
+      "vaccine-code": "EU/1/21/1529",
+      "vaccine-manufacturer": "ORG-100001699",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ],
+      "note": "Use also for AstraZeneca covid-19 vaccines, except R-COVI, Covishield and Covid-19 (recombinant) by Fiocruz."
+    },
+    "Jcovden": {
+      "vaccine-code": "EU/1/20/1525",
+      "vaccine-manufacturer": "ORG-100001417",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ],
+      "note": "Previously known as COVID-19 Vaccine Janssen."
+    },
+    "CVnCoV": {
+      "vaccine-code": "CVnCoV",
+      "vaccine-manufacturer": "ORG-100006270",
+      "sct-codes": [
+        "1119349007",
+        "J07BX03"
+      ]
+    },
+    "NVX-CoV2373": {
+      "vaccine-code": "NVX-CoV2373 (deprecated)",
+      "vaccine-manufacturer": "ORG-100032020",
+      "sct-codes": [
+        "J07BX03",
+        "1162643001"
+      ],
+      "note": "Do not use this code for new certificates, see entry for Nuvaxovid."
+    },
+    "Sputnik V": {
+      "vaccine-code": "Sputnik-V",
+      "vaccine-manufacturer": "Gamaleya-Research-Institute",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ]
+    },
+    "Convidecia": {
+      "vaccine-code": "Convidecia",
+      "vaccine-manufacturer": "ORG-100013793",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ]
+    },
+    "EpiVacCorona": {
+      "vaccine-code": "EpiVacCorona",
+      "vaccine-manufacturer": "Vector-Institute",
+      "sct-codes": [
+        "J07BX03",
+        "1162643001"
+      ]
+    },
+    "BBIBP-CorV": {
+      "vaccine-code": "BBIBP-CorV",
+      "vaccine-manufacturer": "ORG-100020693",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ]
+    },
+    "Inactivated SARS-CoV-2 (Vero Cell)": {
+      "vaccine-code": "Inactivated-SARS-CoV-2-Vero-Cell",
+      "vaccine-manufacturer": "ORG-100010771",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ],
+      "note": "Do not use this code for new certificates, see entry for WIBP-CorV."
+    },
+    "CoronaVac": {
+      "vaccine-code": "CoronaVac",
+      "vaccine-manufacturer": "Sinovac-Biotech",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ],
+      "note": "Do not use for Vacina adsorvida covid-19 (inativada) by Institito Butantan."
+    },
+    "Covaxin": {
+      "vaccine-code": "Covaxin",
+      "vaccine-manufacturer": "Bharat-Biotech",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ],
+      "note": "Also known as BBV152 A, B, C."
+    },
+    "Covishield": {
+      "vaccine-code": "Covishield",
+      "vaccine-manufacturer": "ORG-100001981",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ],
+      "note": "Also known as ChAdOx1_nCoV-19."
+    },
+    "Covid-19 (recombinant)": {
+      "vaccine-code": "Covid-19-recombinant",
+      "vaccine-manufacturer": "Fiocruz",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ]
+    },
+    "R-COVI": {
+      "vaccine-code": "R-COVI",
+      "vaccine-manufacturer": "ORG-100007893",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ]
+    },
+    "CoviVac": {
+      "vaccine-code": "CoviVac",
+      "vaccine-manufacturer": "Chumakov-Federal-Scientific-Center",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ]
+    },
+    "Sputnik Light": {
+      "vaccine-code": "Sputnik-Light",
+      "vaccine-manufacturer": "Gamaleya-Research-Institute",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ]
+    },
+    "Hayat-Vax": {
+      "vaccine-code": "Hayat-Vax",
+      "vaccine-manufacturer": "ORG-100023050",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ]
+    },
+    "Abdala": {
+      "vaccine-code": "Abdala",
+      "vaccine-manufacturer": "CIGB",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as CIGB-66."
+    },
+    "WIBP-CorV": {
+      "vaccine-code": "WIBP-CorV",
+      "vaccine-manufacturer": "Sinopharm-WIBP",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ],
+      "note": "Previously known as Inactivated SARS-CoV-2 (Vero Cell)."
+    },
+    "MVC COVID-19 vaccine": {
+      "vaccine-code": "MVC-COV1901",
+      "vaccine-manufacturer": "ORG-100033914",
+      "sct-codes": [
+        "J07BX03",
+        "1162643001"
+      ],
+      "note": "Also known as Medigen COVID-19 vaccine."
+    },
+    "Nuvaxovid": {
+      "vaccine-code": "EU/1/21/1618",
+      "vaccine-manufacturer": "ORG-100032020",
+      "sct-codes": [
+        "J07BX03",
+        "1162643001"
+      ],
+      "note": "Previously known as NVX-CoV2373."
+    },
+    "Covovax": {
+      "vaccine-code": "Covovax",
+      "vaccine-manufacturer": "ORG-100001981",
+      "sct-codes": [
+        "J07BX03",
+        "1162643001"
+      ],
+      "note": "Do not confuse with Nuvaxovid."
+    },
+    "Vidprevtyn": {
+      "vaccine-code": "Vidprevtyn (deprecated)",
+      "vaccine-manufacturer": "ORG-100000788",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Do not use this code for new certificates, see entry for VidPrevtyn Beta."
+    },
+    "VLA2001": {
+      "vaccine-code": "VLA2001 (deprecated)",
+      "vaccine-manufacturer": "ORG-100036422",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Do not use this code for new certificates, see entry for COVID-19 Vaccine (inactivated, adjuvanted) Valneva."
+    },
+    "Sputnik M": {
+      "vaccine-code": "Sputnik-M",
+      "vaccine-manufacturer": "Gamaleya-Research-Institute",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ],
+      "note": "Do not confuse with Sputnik V or Sputnik Light."
+    },
+    "EpiVacCorona-N": {
+      "vaccine-code": "EpiVacCorona-N",
+      "vaccine-manufacturer": "Vector-Institute",
+      "sct-codes": [
+        "J07BX03",
+        "1162643001"
+      ],
+      "note": "Do not confuse with EpiVacCorona. Also know as Aurora-CoV."
+    },
+    "Vacina adsorvida covid-19 (inativada)": {
+      "vaccine-code": "Covid-19-adsorvida-inativada",
+      "vaccine-manufacturer": "Instituto-Butantan",
+      "sct-codes": [
+        "J07BX03",
+        "1157024006"
+      ]
+    },
+    "NVSI-06-08": {
+      "vaccine-code": "NVSI-06-08",
+      "vaccine-manufacturer": "NVSI",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as Recombinant SARS-CoV-2 vaccine (CHO Cell)."
+    },
+    "YS-SC2-010": {
+      "vaccine-code": "YS-SC2-010",
+      "vaccine-manufacturer": "Yisheng-Biopharma",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as PIKA-Adjuvanted Recombinant SARS-CoV-2 Spike (S) Protein Subunit vaccine."
+    },
+    "SCTV01C": {
+      "vaccine-code": "SCTV01C",
+      "vaccine-manufacturer": "ORG-100026614",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as Bivalent Recombinant Trimeric S Protein vaccine."
+    },
+    "Covifenz": {
+      "vaccine-code": "Covifenz",
+      "vaccine-manufacturer": "ORG-100008549",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as CoVLP and Medicago plant-based VLP."
+    },
+    "AZD2816": {
+      "vaccine-code": "AZD2816",
+      "vaccine-manufacturer": "ORG-100001699",
+      "sct-codes": [
+        "J07BX03",
+        "29061000087103"
+      ]
+    },
+    "Soberana 02": {
+      "vaccine-code": "Soberana-02",
+      "vaccine-manufacturer": "Finlay-Institute",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as FINLAY-FR-2."
+    },
+    "Soberana Plus": {
+      "vaccine-code": "Soberana-Plus",
+      "vaccine-manufacturer": "Finlay-Institute",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Also known as FINLAY-FR-1A."
+    },
+    "COVID-19 Vaccine Valneva": {
+      "vaccine-code": "EU/1/21/1624",
+      "vaccine-manufacturer": "ORG-100036422",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Previously known as VLA2001."
+    },
+    "VidPrevtyn Beta": {
+      "vaccine-code": "EU/1/21/1580",
+      "vaccine-manufacturer": "ORG-100000788",
+      "sct-codes": [
+        "J07BX03"
+      ],
+      "note": "Previously known as Vidprevtyn."
+    }
+  }
+}

--- a/vaccine-prophylaxis.json
+++ b/vaccine-prophylaxis.json
@@ -1,14 +1,7 @@
 {
   "valueSetId": "sct-vaccines-covid-19",
-  "valueSetDate": "2021-04-27",
+  "valueSetDate": "2023-01-25",
   "valueSetValues": {
-    "1119349007": {
-      "display": "SARS-CoV-2 mRNA vaccine",
-      "lang": "en",
-      "active": true,
-      "version": "http://snomed.info/sct/900000000000207008/version/20210131",
-      "system": "http://snomed.info/sct"
-    },
     "1119305005": {
       "display": "SARS-CoV-2 antigen vaccine",
       "lang": "en",
@@ -16,10 +9,17 @@
       "version": "http://snomed.info/sct/900000000000207008/version/20210131",
       "system": "http://snomed.info/sct"
     },
-    "J07BX03": {
-      "display": "covid-19 vaccines",
+    "1119349007": {
+      "display": "SARS-CoV-2 mRNA vaccine",
       "lang": "en",
       "active": true,
+      "version": "http://snomed.info/sct/900000000000207008/version/20210131",
+      "system": "http://snomed.info/sct"
+    },
+    "J07BX03": {
+      "display": "covid-19 vaccines (deprecated)",
+      "lang": "en",
+      "active": false,
       "version": "2021-01",
       "system": "http://www.whocc.no/atc"
     },
@@ -42,6 +42,27 @@
       "lang": "en",
       "active": true,
       "version": "2022-01-31",
+      "system": "http://snomed.info/sct"
+    },
+    "28531000087107": {
+      "display": "COVID-19 vaccine",
+      "lang": "en",
+      "active": true,
+      "version": "2022-12-31",
+      "system": "http://snomed.info/sct"
+    },
+    "30141000087107": {
+      "display": "SARS-CoV-2 virus-like particle antigen vaccine",
+      "lang": "en",
+      "active": true,
+      "version": "2022-12-31",
+      "system": "http://snomed.info/sct"
+    },
+    "1187593009": {
+      "display": "SARS-CoV-2 DNA plasmid encoding spike protein vaccine",
+      "lang": "en",
+      "active": true,
+      "version": "2022-12-31",
       "system": "http://snomed.info/sct"
     }
   }


### PR DESCRIPTION
I propose to release 2.11.0 as it currently stands, and immediately after release start to prepare 2.12.0 with the documentation changes, as well as other changes that don't impact the value sets directly (apart maybe from RAT).